### PR TITLE
make use of new base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM httpd:2.2
+FROM immobilienscout24/httpd_with_imagemagick_incl_webp 
+
+ADD . /var/tmp/build
 
 RUN buildDeps=' \
     		autotools-dev \
@@ -8,13 +10,11 @@ RUN buildDeps=' \
     	' && \
     	set -x -v && \
         apt-get update && \
-        apt-get -y --no-install-recommends install $buildDeps libmagickcore-dev libmagickwand-dev  libcurl4-gnutls-dev
-
-ADD . /var/tmp/build
-RUN  cd /var/tmp/build && \
+        apt-get -y --no-install-recommends install $buildDeps && \
+        cd /var/tmp/build && \
         ./autorun.sh && \
         export LDFLAGS="$LDFLAGS -L/usr/lib64/httpd" && \
-        export CFLAGS="$CFLAGS -I/usr/include/httpd -I/usr/include/ImageMagick" && \
+        export CFLAGS="$CFLAGS -I/usr/include/httpd -I/usr/include/ImageMagick -DAWSBUILD" && \
         ./configure && \
         make && \
         install -m 0644 src/.libs/libmod_dims.so -D $HTTPD_PREFIX/modules/mod_dims.so && \

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -1022,6 +1022,11 @@ dims_process_image(dims_request_rec *d)
         MagickProfileImage(d->wand, "ICC", rgb_icc, sizeof(rgb_icc));
     }
 
+    /* MagickAutoOrientImage is only available from version 6.8.9-9 onwards - dc=no, cloud=yes */
+    #ifdef AWSBUILD
+    	MagickAutoOrientImage(d->wand);
+    #endif
+
     /* Process operations, iterating over all frames of this image. */
     ssize_t images = MagickGetIteratorIndex(d->wand);
     if (images == 0) {


### PR DESCRIPTION
-make use of newly created base image from https://github.com/ImmobilienScout24/httpd_with_imagemagick_incl_webp
-use MagickAutoOrientImage in our docker-version